### PR TITLE
Add url helper support for schema serving endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,30 @@ And you can get your schemas through the path `/schemas` like following:
 ```
 # Get `app/schemas/posts/create.*` as application/json
 GET /schemas/posts/create.json
+GET /schemas/posts/create
 
 # Get `app/schemas/posts/update.*` as text/yaml
 GET /schemas/posts/update.yaml
+```
+
+To get a path to a specific schema's endpoint, call `json_schema_rails.schema_path(schema_name)` or `json_schema_rails.schema_url(schema_name)`.
+
+```ruby
+# In your controller or view
+json_schema_rails.schema_path("posts/create")  # "/schemas/posts/create"
+json_schema_rails.schema_url("posts/update")   # "http://example.com/schemas/posts/create"
+```
+
+You can change `json_schema_rails` part of above by specifying `as` parameter when mounting the route:
+
+```ruby
+Your::Application.routes.draw do
+  mount JsonSchemaRails::Engine => '/schemas', as: 'json_schema'
+end
+
+# And you can call the helpers as
+json_schema.schema_path("posts/create")
+json_schema.schema_url("posts/update")
 ```
 
 ### Validate schema files

--- a/app/controllers/json_schema_rails/schemas_controller.rb
+++ b/app/controllers/json_schema_rails/schemas_controller.rb
@@ -1,7 +1,7 @@
 module JsonSchemaRails
   class SchemasController < ApplicationController
-    def get
-      schema = JsonSchemaRails.lookup_schema(params[:schema])
+    def show
+      schema = JsonSchemaRails.lookup_schema(params[:id])
       raise ActionController::RoutingError.new('No Such Schema') unless schema
 
       respond_to do |format|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 JsonSchemaRails::Engine.routes.draw do
-  get '/:schema(.:format)', to: 'schemas#get', constraints: { schema: /[\/a-zA-Z0-9_-]+/ }
+  resources :schemas, only: :show, path: '', id: /[\/a-zA-Z0-9_-]+/, defaults: { format: 'json' }
 end

--- a/spec/dummy_apps/rails3/app/controllers/helpers_controller.rb
+++ b/spec/dummy_apps/rails3/app/controllers/helpers_controller.rb
@@ -1,0 +1,11 @@
+class HelpersController < ApplicationController
+  def show_schema_path
+    path = json_schema_rails.schema_path(params[:schema_name])
+    render text: path
+  end
+
+  def show_schema_url
+    url = json_schema_rails.schema_url(params[:schema_name])
+    render text: url
+  end
+end

--- a/spec/dummy_apps/rails3/config/routes.rb
+++ b/spec/dummy_apps/rails3/config/routes.rb
@@ -2,6 +2,9 @@ Dummy::Application.routes.draw do
   mount JsonSchemaRails::Engine => '/schemas'
   resources :posts, only: [:create, :update]
 
+  get 'helpers/schema_path', to: 'helpers#show_schema_path'
+  get 'helpers/schema_url',  to: 'helpers#show_schema_url'
+
   # The priority is based upon order of creation:
   # first created -> highest priority.
 

--- a/spec/dummy_apps/rails4/app/controllers/helpers_controller.rb
+++ b/spec/dummy_apps/rails4/app/controllers/helpers_controller.rb
@@ -1,0 +1,11 @@
+class HelpersController < ApplicationController
+  def show_schema_path
+    path = json_schema_rails.schema_path(params[:schema_name])
+    render text: path
+  end
+
+  def show_schema_url
+    url = json_schema_rails.schema_url(params[:schema_name])
+    render text: url
+  end
+end

--- a/spec/dummy_apps/rails4/config/routes.rb
+++ b/spec/dummy_apps/rails4/config/routes.rb
@@ -2,6 +2,9 @@ Rails.application.routes.draw do
   mount JsonSchemaRails::Engine => '/schemas'
   resources :posts, only: [:create, :update]
 
+  get 'helpers/schema_path', to: 'helpers#show_schema_path'
+  get 'helpers/schema_url',  to: 'helpers#show_schema_url'
+
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/spec/integration/helpers_controller_spec.rb
+++ b/spec/integration/helpers_controller_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+RSpec.describe HelpersController, type: :controller do
+  describe "schema_path helper" do
+    it "returns a path to schema endpoint" do
+      get "show_schema_path", { "schema_name" => "posts/create" }
+      expect(response.body).to eq "/schemas/posts/create"
+    end
+  end
+
+  describe "schema_url helper" do
+    it "returns a URL to schema endpoint" do
+      get "show_schema_url", { "schema_name" => "posts/create" }
+      expect(response.body).to eq "#{request.base_url}/schemas/posts/create"
+    end
+  end
+end

--- a/spec/integration/schemas_controller_spec.rb
+++ b/spec/integration/schemas_controller_spec.rb
@@ -3,11 +3,20 @@ require 'spec_helper'
 RSpec.describe JsonSchemaRails::SchemasController, type: :request do
   describe "GET #get" do
     context "with existing schema" do
-      before { get "/schemas/posts/create.#{format}" }
+      before { get "/schemas/posts/create#{format}" }
       let(:expected_schema) { YAML.load_file(Rails.root.join('app', 'schemas', 'posts', 'create.yml').to_s) }
 
       context "as json" do
-        let(:format) { "json" }
+        let(:format) { ".json" }
+        it "returns the schema as json" do
+          expect(response).to be_success
+          expect(response.content_type).to eq :json
+          expect(response.body).to eq expected_schema.to_json
+        end
+      end
+
+      context "without format" do
+        let(:format) { "" }
         it "returns the schema as json" do
           expect(response).to be_success
           expect(response.content_type).to eq :json
@@ -16,7 +25,7 @@ RSpec.describe JsonSchemaRails::SchemasController, type: :request do
       end
 
       context "as yaml" do
-        let(:format) { "yaml" }
+        let(:format) { ".yaml" }
         it "returns the schema as yaml" do
           expect(response).to be_success
           expect(response.content_type).to eq :yaml


### PR DESCRIPTION
For this, the route for SchemaController is changed to use "resources"
instead of "get", so that the url helper is automatically defined.

In addition, set default format to "json" so that we don't need specific
extension for the endpoints.
