### PR TITLE
Fix route to get schema for Rails 4.1.2

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 JsonSchemaRails::Engine.routes.draw do
-  resources :schemas, only: :show, path: '', id: /[\/a-zA-Z0-9_-]+/, defaults: { format: 'json' }
+  get '*id(.:format)', to: 'schemas#show', as: :schema, id: /[\/a-zA-Z0-9_-]+/, defaults: { format: 'json' }
 end


### PR DESCRIPTION
Due to changes in Rails 4.1.2, slashes in a path generated by
json_schema_rails url helper were escaped to '%2F', which is not
comfortable for nested schema names.

To avoid the escaping, we need to use wildcard segments ('*foo') to
express a parameter of schema name. So stopped using "resources" routing
and uses "get" with "as" parameter for url helpers.
